### PR TITLE
Fixing the user to use for git-xet login

### DIFF
--- a/install-git-xet.sh
+++ b/install-git-xet.sh
@@ -31,10 +31,10 @@ function login() {
   if [ -z "$host" ]
   then
     echo "Authenticating with XetHub.com..."
-    git xet login -u $username -e $email -p $token ; local CODE=$?
+    sudo su $SUDO_USER git xet login -u $username -e $email -p $token ; local CODE=$?
   else
     echo "Authenticating with ${host}..."
-    git xet login -u $username -e $email -p $token --host $host ; local CODE=$?
+    sudo su $SUDO_USER git xet login -u $username -e $email -p $token --host $host ; local CODE=$?
   fi
   return $CODE
 }

--- a/install-git-xet.sh
+++ b/install-git-xet.sh
@@ -31,10 +31,10 @@ function login() {
   if [ -z "$host" ]
   then
     echo "Authenticating with XetHub.com..."
-    sudo su -u $SUDO_USER git xet login -u $username -e $email -p $token ; local CODE=$?
+    sudo -u $SUDO_USER git xet login -u $username -e $email -p $token ; local CODE=$?
   else
     echo "Authenticating with ${host}..."
-    sudo su -u $SUDO_USER git xet login -u $username -e $email -p $token --host $host ; local CODE=$?
+    sudo -u $SUDO_USER git xet login -u $username -e $email -p $token --host $host ; local CODE=$?
   fi
   return $CODE
 }

--- a/install-git-xet.sh
+++ b/install-git-xet.sh
@@ -31,10 +31,10 @@ function login() {
   if [ -z "$host" ]
   then
     echo "Authenticating with XetHub.com..."
-    sudo su $SUDO_USER git xet login -u $username -e $email -p $token ; local CODE=$?
+    sudo su -u $SUDO_USER git xet login -u $username -e $email -p $token ; local CODE=$?
   else
     echo "Authenticating with ${host}..."
-    sudo su $SUDO_USER git xet login -u $username -e $email -p $token --host $host ; local CODE=$?
+    sudo su -u $SUDO_USER git xet login -u $username -e $email -p $token --host $host ; local CODE=$?
   fi
   return $CODE
 }

--- a/install-git-xet.sh
+++ b/install-git-xet.sh
@@ -31,10 +31,10 @@ function login() {
   if [ -z "$host" ]
   then
     echo "Authenticating with XetHub.com..."
-    sudo -u $SUDO_USER git xet login -u $username -e $email -p $token ; local CODE=$?
+    sudo -u $SUDO_USER -- git xet login -u $username -e $email -p $token ; local CODE=$?
   else
     echo "Authenticating with ${host}..."
-    sudo -u $SUDO_USER git xet login -u $username -e $email -p $token --host $host ; local CODE=$?
+    sudo -u $SUDO_USER -- git xet login -u $username -e $email -p $token --host $host ; local CODE=$?
   fi
   return $CODE
 }


### PR DESCRIPTION
We were calling `git xet login` with the super user, so the credentials were getting created against that account. This was fine when the root user was the same as the one running the install command. On public machines or EC2 instance, this is not the case.

We need to run `git-xet` install with `su` but run login with the executing user. This command sets the user to the one who called sudo.